### PR TITLE
Add interactive booth selection map

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -2157,6 +2157,7 @@ function renderHistoricalView(container) {
                 attribution: '© OpenStreetMap contributors'
             }).addTo(boothMap);
 
+            // Use a simple layer group so all booth pins remain individual
             mapMarkers = L.layerGroup().addTo(boothMap);
 
             Object.entries(POLLING_PLACES).forEach(([name, info]) => {


### PR DESCRIPTION
## Summary
- Add booth map to booth results page and move detailed table below vote distribution
- Enable selecting booths by clicking map markers or the dropdown, keeping markers unclustered
- Display individual booth markers without clustering for statewide and electorate views
- Show booth and candidate vote percentage columns in booth results table
- Plot party performance charts by vote percentage instead of raw votes
- Remember last selected view and filters across page reloads

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a03b66908332aec6c81329e27bed