### PR TITLE
Fix LC booth map filtering for legislative council mode

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -2162,11 +2162,27 @@ function renderHistoricalView(container) {
 
             mapMarkers = L.layerGroup().addTo(boothMap);
 
+            // For LC elections, build a set of booth names that belong to the selected electorate
+            let lcBoothSet = null;
+            if (currentElectionType === 'lc' && electorate) {
+                const year = document.getElementById('yearSelect').value;
+                const data = getCurrentData(year, 'electorate', electorate, '', '');
+                lcBoothSet = new Set();
+                data.forEach(candidate => {
+                    if (Array.isArray(candidate.b)) {
+                        candidate.b.forEach(b => lcBoothSet.add(keyForBooth(b.n)));
+                    }
+                });
+            }
+
             Object.entries(POLLING_PLACES).forEach(([name, info]) => {
-                if (electorate && info.electorate !== electorate) return;
+                if (electorate) {
+                    if (currentElectionType === 'state' && info.electorate !== electorate) return;
+                    if (currentElectionType === 'lc' && lcBoothSet && !lcBoothSet.has(keyForBooth(name))) return;
+                }
 
                 const marker = L.marker([info.lat, info.lng]).addTo(mapMarkers);
-                marker.bindPopup(`<div class="booth-popup"><h3>${name}</h3><p>${info.electorate}</p></div>`);
+                marker.bindPopup(`<div class="booth-popup"><h3>${name}</h3><p>${electorate || info.electorate}</p></div>`);
                 marker.on('click', () => {
                     const boothSelect = document.getElementById('boothSelect');
                     const options = Array.from(boothSelect.options);


### PR DESCRIPTION
## Summary
- detect LC elections in `createBoothSelectionMap`
- build booth set from LC data and filter map markers by membership
- show selected electorate name in booth popups

## Testing
- `node -e "const fs=require('fs');const polling=JSON.parse(fs.readFileSync('Polling Locations - Year and Election Type.json','utf8'));const data=JSON.parse(fs.readFileSync('converted_election_data_full.json','utf8')).ELECTION_DATA;const electorate='Bass';const stateCount=Object.entries(polling).filter(([n,info])=>info.electorate===electorate).length;console.log('state booths in Bass',stateCount);const lcElectorate='Elwick';const year='2024';const rows=data.lc[year].filter(r=>r.d===lcElectorate);const boothSet=new Set();rows.forEach(r=>{if(Array.isArray(r.b))r.b.forEach(b=>boothSet.add(b.n));});console.log('lc booths sample',Array.from(boothSet).slice(0,5));console.log('contains Glenorchy?',boothSet.has('Glenorchy'));"`


------
https://chatgpt.com/codex/tasks/task_e_68a2b990a02c833288bdfd176304169c