### PR TITLE
Fix geojson overlay fetch URLs

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -2270,7 +2270,7 @@ function renderHistoricalView(container) {
                         });
                     })();
                 }
-boothMap.addLayer(mapMarkers);
+                boothMap.addLayer(mapMarkers);
                 
                 
                 // --- GeoJSON Overlay selector (State, LegCo, LGA) [attached directly to boothMap] ---
@@ -2279,9 +2279,9 @@ boothMap.addLayer(mapMarkers);
                     map.__overlayCtlAdded = true;
 
                     const OVERLAY_URLS = {
-                        state: 'https://raw.githubusercontent.com/williammanning68/Test-Fetch/main/State Election Electorate Boundaries.geojson',
-                        legco: 'https://raw.githubusercontent.com/williammanning68/Test-Fetch/main/Legislative Council Electorate Boundaries.geojson',
-                                            };
+                        state: 'https://raw.githubusercontent.com/williammanning68/Test-Fetch/main/State%20Election%20Electorate%20Boundaries.geojson',
+                        legco: 'https://raw.githubusercontent.com/williammanning68/Test-Fetch/main/Legislative%20Council%20Electorate%20Boundaries.geojson',
+                    };
 
                     const state = { current: null, cache: {} };
 


### PR DESCRIPTION
## Summary
- encode spaces in overlay GeoJSON URLs for state and Legislative Council boundaries
- clarify map marker initialisation

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68a31174f9b88332966a1e17644e4abb