### PR TITLE
Ensure dropdowns refresh before dashboard render

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -911,16 +911,24 @@ function getPartyColor(party) {
         }
         
         function switchElectionType(type) {
+            if (currentElectionType !== type) {
+                document.getElementById('electorateSelect').value = '';
+                document.getElementById('boothSelect').value = '';
+            }
             currentElectionType = type;
             document.getElementById('btnState').classList.toggle('active', type === 'state');
             document.getElementById('btnLC').classList.toggle('active', type === 'lc');
             updateYearDropdown();
             updateDashboard();
         }
-        
+
         function updateDashboard() {
             const scope = document.getElementById('scopeSelect').value;
             const year = document.getElementById('yearSelect').value;
+
+            updateElectorateDropdown();
+            if (scope === 'booth') updateBoothDropdown();
+
             const electorate = document.getElementById('electorateSelect').value;
             const booth = document.getElementById('boothSelect').value;
             const candidate = document.getElementById('candidateSelect').value;
@@ -974,8 +982,6 @@ function getPartyColor(party) {
                     break;
             }
             
-            updateElectorateDropdown();
-            if (scope === 'booth') updateBoothDropdown();
             if (scope === 'candidate') updateCandidateDropdown();
         }
         


### PR DESCRIPTION
## Summary
- Clear electorate and booth selections when switching between election types
- Populate electorate and booth dropdowns before reading selections and render dashboard with updated values

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e4d5bdb08332820a55ffc239e77a