### PR TITLE
Add candidate summary with quota calculations

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -1330,7 +1330,37 @@ function getPartyColor(party) {
         
         function renderCandidateView(container, year, candidate) {
             const candidateName = candidate || 'Select a candidate';
+            let summaryHtml = '';
+
+            if (candidate) {
+                const data = getCurrentData(year, 'candidate', '', '', candidate);
+
+                if (data.length > 0) {
+                    const cand = data[0];
+                    const party = cand.p;
+                    const electorate = cand.d;
+                    const seats = 5;
+                    const divisionData = getCurrentData(year, 'electorate', electorate, '', '');
+                    const totalVotes = divisionData.reduce((sum, c) => sum + (c.v || 0), 0);
+                    const quota = Math.floor(totalVotes / (seats + 1)) + 1;
+                    const quotaShare = quota ? (cand.v / quota).toFixed(2) : '0';
+
+                    summaryHtml = `
+                <div class="panel full-width">
+                    <h2>Candidate Summary</h2>
+                    <p><strong>Party:</strong> ${getPartyName(party)}</p>
+                    <p><strong>Electorate:</strong> ${electorate}</p>
+                    <p><strong>Election Year:</strong> ${year}</p>
+                    <p><strong>Division Size:</strong> ${seats}</p>
+                    <p><strong>Total Formal Votes:</strong> ${totalVotes.toLocaleString()}</p>
+                    <p><strong>Droop Quota:</strong> ${quota.toLocaleString()}</p>
+                    <p><strong>Quota Share:</strong> ${quotaShare}</p>
+                </div>`;
+                }
+            }
+
             container.innerHTML = `
+                ${summaryHtml}
                 <div class="panel full-width">
                     <h2>Candidate Profile - ${candidateName}</h2>
                     <div class="panel-grid">
@@ -1358,7 +1388,7 @@ function getPartyColor(party) {
                     </div>
                 </div>
             `;
-            
+
             if (candidate) {
                 loadCandidateData(year, candidate);
             }


### PR DESCRIPTION
## Summary
- Extend candidate view to show party, electorate, election year, division size, total votes, Droop quota and quota share.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Test-Fetch/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a419d60be88332bc8d2160b8e1034e