### PR TITLE
Revamp candidate analysis view

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -1330,35 +1330,175 @@ function getPartyColor(party) {
         
         function renderCandidateView(container, year, candidate) {
             const candidateName = candidate || 'Select a candidate';
+            const candidateData = getCurrentData(year, 'candidate', '', '', candidate)[0];
+            const party = candidateData ? candidateData.p : '';
+            const electorate = candidateData ? candidateData.d : '';
+
             container.innerHTML = `
-                <div class="panel full-width">
-                    <h2>Candidate Profile - ${candidateName}</h2>
-                    <div class="panel-grid">
-                        <div>
-                            <h3>Performance by Location</h3>
-                            <div class="chart-container">
-                                <canvas id="candidateLocationChart"></canvas>
-                            </div>
-                        </div>
-                        <div>
-                            <h3>Booth-by-Booth Results</h3>
-                            <div class="table-container">
-                                <table>
-                                    <thead>
-                                        <tr>
-                                            <th>Booth</th>
-                                            <th>Electorate</th>
-                                            <th>Votes</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody id="candidateBoothBody"></tbody>
-                                </table>
-                            </div>
-                        </div>
+        <div class="panel full-width">
+            <h2>${candidateName}</h2>
+            <p style="margin-top: -0.5rem; color: #666;">
+                <span style="color: ${getPartyColor(party)}; font-weight: 600;">${getPartyName(party)}</span> 
+                • ${electorate} • ${currentElectionType === 'state' ? 'State Election' : 'Legislative Council'} ${year}
+            </p>
+        </div>
+
+        <!-- Topline Performance -->
+        <div class="panel full-width">
+            <h2>Topline Performance</h2>
+            <div class="booth-stats-grid">
+                <div class="stat-card">
+                    <h3>Primary Votes</h3>
+                    <div class="stat-value" id="primaryVotes">—</div>
+                    <div class="stat-label" id="primaryPercent">—</div>
+                </div>
+                <div class="stat-card">
+                    <h3>Party Vote Share</h3>
+                    <div class="stat-value" id="partyShare">—</div>
+                    <div class="stat-label">of party's electorate votes</div>
+                </div>
+                <div class="stat-card">
+                    <h3>Rank in Party</h3>
+                    <div class="stat-value" id="partyRank">—</div>
+                    <div class="stat-label" id="partyRankLabel">—</div>
+                </div>
+                <div class="stat-card">
+                    <h3>Overall Rank</h3>
+                    <div class="stat-value" id="overallRank">—</div>
+                    <div class="stat-label" id="overallRankLabel">—</div>
+                </div>
+            </div>
+            
+            <div class="panel-grid" style="margin-top: 1.5rem;">
+                <div>
+                    <h3>Historical Comparison</h3>
+                    <div class="table-container small">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Metric</th>
+                                    <th>Current</th>
+                                    <th>Previous</th>
+                                    <th>Swing</th>
+                                </tr>
+                            </thead>
+                            <tbody id="historicalComparisonBody">
+                                <tr><td colspan="4">Loading...</td></tr>
+                            </tbody>
+                        </table>
                     </div>
                 </div>
-            `;
+                <div>
+                    <h3>Multi-Cycle Trend</h3>
+                    <div class="chart-container small">
+                        <canvas id="trendChart"></canvas>
+                    </div>
+                </div>
+            </div>
+        </div>
+        
+        <!-- Booth Performance Analysis -->
+        <div class="panel full-width">
+            <h2>Booth Performance Analysis</h2>
+            <div class="panel-grid">
+                <div>
+                    <h3>Top 10 Booths</h3>
+                    <div class="table-container small">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Booth</th>
+                                    <th>Votes</th>
+                                    <th>%</th>
+                                    <th>Swing</th>
+                                </tr>
+                            </thead>
+                            <tbody id="topBoothsBody">
+                                <tr><td colspan="4">Loading...</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div>
+                    <h3>Bottom 10 Booths</h3>
+                    <div class="table-container small">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Booth</th>
+                                    <th>Votes</th>
+                                    <th>%</th>
+                                    <th>Swing</th>
+                                </tr>
+                            </thead>
+                            <tbody id="bottomBoothsBody">
+                                <tr><td colspan="4">Loading...</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
             
+            <div style="margin-top: 1.5rem;">
+                <h3>Booth Map - Candidate Performance</h3>
+                <div id="boothMap"></div>
+            </div>
+        </div>
+        
+        <!-- Consistency & Distribution -->
+        <div class="panel full-width">
+            <h2>Consistency & Distribution Analysis</h2>
+            <div class="booth-stats-grid">
+                <div class="stat-card">
+                    <h3>Median Booth %</h3>
+                    <div class="stat-value" id="medianBooth">—</div>
+                    <div class="stat-label">middle performance</div>
+                </div>
+                <div class="stat-card">
+                    <h3>IQR</h3>
+                    <div class="stat-value" id="iqrBooth">—</div>
+                    <div class="stat-label">interquartile range</div>
+                </div>
+                <div class="stat-card">
+                    <h3>Coefficient of Variation</h3>
+                    <div class="stat-value" id="cvBooth">—</div>
+                    <div class="stat-label">consistency measure</div>
+                </div>
+                <div class="stat-card">
+                    <h3>Outlier Booths</h3>
+                    <div class="stat-value" id="outlierCount">—</div>
+                    <div class="stat-label">±2σ from mean</div>
+                </div>
+            </div>
+            
+            <div class="panel-grid" style="margin-top: 1.5rem;">
+                <div>
+                    <h3>Distribution of Booth Performance</h3>
+                    <div class="chart-container">
+                        <canvas id="distributionChart"></canvas>
+                    </div>
+                </div>
+                <div>
+                    <h3>Outlier Booths</h3>
+                    <div class="table-container">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Booth</th>
+                                    <th>%</th>
+                                    <th>Deviation</th>
+                                    <th>Type</th>
+                                </tr>
+                            </thead>
+                            <tbody id="outlierBoothsBody">
+                                <tr><td colspan="4">Loading...</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>`;
+
             if (candidate) {
                 loadCandidateData(year, candidate);
             }
@@ -1930,38 +2070,351 @@ function renderHistoricalView(container) {
         
         function loadCandidateData(year, candidate) {
             const data = getCurrentData(year, 'candidate', '', '', candidate);
-            
+
             if (!candidate || data.length === 0) {
-                document.getElementById('candidateBoothBody').innerHTML = 
-                    '<tr><td colspan="3">No data available for selected candidate</td></tr>';
+                document.getElementById('primaryVotes').textContent = '—';
                 return;
             }
-            
+
             const candidateData = data[0];
+            const electorate = candidateData.d;
+            const party = candidateData.p;
+            const normalizedParty = normalizeParty(party);
+
+            const electorateData = getCurrentData(year, 'electorate', electorate, '', '');
+
+            const totalVotes = candidateData.v;
+            const electorateTotalVotes = electorateData.reduce((sum, c) => sum + c.v, 0);
+            const primaryPercent = (totalVotes / electorateTotalVotes * 100).toFixed(2);
+
+            const partyCandidates = electorateData.filter(c => normalizeParty(c.p) === normalizedParty);
+            const partyTotalVotes = partyCandidates.reduce((sum, c) => sum + c.v, 0);
+            const partyShare = partyTotalVotes > 0 ? (totalVotes / partyTotalVotes * 100).toFixed(1) : 0;
+
+            const sortedCandidates = [...electorateData].sort((a, b) => b.v - a.v);
+            const overallRank = sortedCandidates.findIndex(c => c.c === candidate) + 1;
+            const sortedParty = partyCandidates.sort((a, b) => b.v - a.v);
+            const partyRank = sortedParty.findIndex(c => c.c === candidate) + 1;
+
+            document.getElementById('primaryVotes').textContent = totalVotes.toLocaleString();
+            document.getElementById('primaryPercent').textContent = `${primaryPercent}% of electorate`;
+            document.getElementById('partyShare').textContent = `${partyShare}%`;
+            document.getElementById('partyRank').textContent = `#${partyRank}`;
+            document.getElementById('partyRankLabel').textContent = `of ${partyCandidates.length} ${getPartyName(party)} candidates`;
+            document.getElementById('overallRank').textContent = `#${overallRank}`;
+            document.getElementById('overallRankLabel').textContent = `of ${sortedCandidates.length} candidates`;
+
             const boothResults = candidateData.b || [];
-            
-            // Sort booths by votes
-            boothResults.sort((a, b) => b.v - a.v);
-            
-            // Update table
-            const tbody = document.getElementById('candidateBoothBody');
-            if (tbody) {
-                tbody.innerHTML = '';
-                
-                boothResults.forEach(booth => {
-                    if (isPhysicalBooth(booth.n)) {
-                        const row = tbody.insertRow();
-                        row.innerHTML = `
-                            <td>${booth.n}</td>
-                            <td>${candidateData.d}</td>
-                            <td>${booth.v.toLocaleString()}</td>
-                        `;
+            const physicalBooths = boothResults.filter(b => isPhysicalBooth(b.n));
+
+            const boothStats = physicalBooths.map(booth => {
+                let boothTotal = 0;
+                electorateData.forEach(c => {
+                    const b = (c.b || []).find(b => b.n === booth.n);
+                    if (b) boothTotal += b.v;
+                });
+                const percentage = boothTotal > 0 ? (booth.v / boothTotal * 100) : 0;
+                return { name: booth.n, votes: booth.v, percentage, total: boothTotal };
+            });
+
+            const sortedBooths = [...boothStats].sort((a, b) => b.percentage - a.percentage);
+
+            const prevYear = getPreviousYear(year);
+            let prevData = null;
+            let prevElectorateData = null;
+            let swing = null;
+
+            if (prevYear) {
+                const prevYearData = currentElectionType === 'state' ? ELECTION_DATA.state[prevYear] : ELECTION_DATA.lc[prevYear];
+                if (prevYearData) {
+                    prevData = prevYearData.find(c => c.c === candidate && c.d === electorate);
+                    prevElectorateData = prevYearData.filter(c => c.d === electorate);
+                    if (prevData) {
+                        const prevTotal = prevElectorateData.reduce((sum, c) => sum + c.v, 0);
+                        const prevPercent = (prevData.v / prevTotal * 100);
+                        swing = (parseFloat(primaryPercent) - prevPercent).toFixed(2);
+                    }
+                }
+            }
+
+            const histBody = document.getElementById('historicalComparisonBody');
+            if (histBody) {
+                if (prevData && swing !== null) {
+                    const prevTotal = prevElectorateData.reduce((sum, c) => sum + c.v, 0);
+                    const prevPercent = (prevData.v / prevTotal * 100).toFixed(2);
+                    const prevRank = [...prevElectorateData].sort((a, b) => b.v - a.v).findIndex(c => c.c === candidate) + 1;
+                    const rankChange = prevRank - overallRank;
+
+                    histBody.innerHTML = `
+                <tr>
+                    <td>Primary Votes</td>
+                    <td>${totalVotes.toLocaleString()}</td>
+                    <td>${prevData.v.toLocaleString()}</td>
+                    <td style="color: ${totalVotes > prevData.v ? 'green' : 'red'}">
+                        ${totalVotes > prevData.v ? '+' : ''}${(totalVotes - prevData.v).toLocaleString()}
+                    </td>
+                </tr>
+                <tr>
+                    <td>Vote %</td>
+                    <td>${primaryPercent}%</td>
+                    <td>${prevPercent}%</td>
+                    <td style="color: ${swing > 0 ? 'green' : 'red'}">
+                        ${swing > 0 ? '+' : ''}${swing}pp
+                    </td>
+                </tr>
+                <tr>
+                    <td>Overall Rank</td>
+                    <td>#${overallRank}</td>
+                    <td>#${prevRank}</td>
+                    <td style="color: ${rankChange > 0 ? 'green' : 'red'}">
+                        ${rankChange > 0 ? '↑' : rankChange < 0 ? '↓' : '—'}${Math.abs(rankChange)}
+                    </td>
+                </tr>
+            `;
+                } else {
+                    histBody.innerHTML = '<tr><td colspan="4">No previous election data available</td></tr>';
+                }
+            }
+
+            const boothSwings = new Map();
+            if (prevData && prevData.b) {
+                physicalBooths.forEach(booth => {
+                    const prevBooth = prevData.b.find(b => b.n === booth.name);
+                    if (prevBooth) {
+                        let prevBoothTotal = 0;
+                        prevElectorateData.forEach(c => {
+                            const b = (c.b || []).find(b => b.n === booth.name);
+                            if (b) prevBoothTotal += b.v;
+                        });
+                        if (prevBoothTotal > 0) {
+                            const currentPct = booth.percentage;
+                            const prevPct = (prevBooth.v / prevBoothTotal * 100);
+                            boothSwings.set(booth.name, (currentPct - prevPct).toFixed(2));
+                        }
                     }
                 });
             }
-            
-            // Create location chart
-            createCandidateLocationChart(boothResults.filter(b => isPhysicalBooth(b.n)));
+
+            const topBody = document.getElementById('topBoothsBody');
+            if (topBody) {
+                topBody.innerHTML = '';
+                sortedBooths.slice(0, 10).forEach(booth => {
+                    const swing = boothSwings.get(booth.name) || '—';
+                    const swingColor = swing !== '—' ? (parseFloat(swing) > 0 ? 'green' : 'red') : '';
+                    const row = topBody.insertRow();
+                    row.innerHTML = `
+                <td>${booth.name}</td>
+                <td>${booth.votes.toLocaleString()}</td>
+                <td>${booth.percentage.toFixed(1)}%</td>
+                <td style="color: ${swingColor}">${swing !== '—' ? (parseFloat(swing) > 0 ? '+' : '') + swing + 'pp' : '—'}</td>
+            `;
+                });
+            }
+
+            const bottomBody = document.getElementById('bottomBoothsBody');
+            if (bottomBody) {
+                bottomBody.innerHTML = '';
+                sortedBooths.slice(-10).reverse().forEach(booth => {
+                    const swing = boothSwings.get(booth.name) || '—';
+                    const swingColor = swing !== '—' ? (parseFloat(swing) > 0 ? 'green' : 'red') : '';
+                    const row = bottomBody.insertRow();
+                    row.innerHTML = `
+                <td>${booth.name}</td>
+                <td>${booth.votes.toLocaleString()}</td>
+                <td>${booth.percentage.toFixed(1)}%</td>
+                <td style="color: ${swingColor}">${swing !== '—' ? (parseFloat(swing) > 0 ? '+' : '') + swing + 'pp' : '—'}</td>
+            `;
+                });
+            }
+
+            const percentages = boothStats.map(b => b.percentage);
+            percentages.sort((a, b) => a - b);
+
+            const median = percentages.length > 0 ? percentages[Math.floor(percentages.length / 2)] : 0;
+            const q1 = percentages[Math.floor(percentages.length * 0.25)];
+            const q3 = percentages[Math.floor(percentages.length * 0.75)];
+            const iqr = q3 - q1;
+
+            const mean = percentages.reduce((sum, p) => sum + p, 0) / percentages.length;
+            const variance = percentages.reduce((sum, p) => sum + Math.pow(p - mean, 2), 0) / percentages.length;
+            const stdDev = Math.sqrt(variance);
+            const cv = mean > 0 ? (stdDev / mean * 100) : 0;
+
+            const outliers = boothStats.filter(b => Math.abs(b.percentage - mean) > 2 * stdDev);
+
+            document.getElementById('medianBooth').textContent = `${median.toFixed(1)}%`;
+            document.getElementById('iqrBooth').textContent = `${iqr.toFixed(1)}pp`;
+            document.getElementById('cvBooth').textContent = `${cv.toFixed(1)}%`;
+            document.getElementById('outlierCount').textContent = outliers.length;
+
+            const outlierBody = document.getElementById('outlierBoothsBody');
+            if (outlierBody) {
+                if (outliers.length > 0) {
+                    outlierBody.innerHTML = '';
+                    outliers.forEach(booth => {
+                        const deviation = ((booth.percentage - mean) / stdDev).toFixed(2);
+                        const type = booth.percentage > mean ? 'Overperforming' : 'Underperforming';
+                        const row = outlierBody.insertRow();
+                        row.innerHTML = `
+                    <td>${booth.name}</td>
+                    <td>${booth.percentage.toFixed(1)}%</td>
+                    <td>${deviation}σ</td>
+                    <td style="color: ${booth.percentage > mean ? 'green' : 'red'}">${type}</td>
+                `;
+                    });
+                } else {
+                    outlierBody.innerHTML = '<tr><td colspan="4">No significant outliers detected</td></tr>';
+                }
+            }
+
+            createCandidateTrendChart(candidate, electorate);
+            createDistributionChart(boothStats);
+            createCandidateBoothMap(boothStats, electorate);
+        }
+
+        function createCandidateTrendChart(candidate, electorate) {
+            const ctx = document.getElementById('trendChart');
+            if (!ctx) return;
+            const years = getAvailableYears();
+            const trendData = [];
+
+            years.forEach(year => {
+                const yearData = currentElectionType === 'state' ? ELECTION_DATA.state[year] : ELECTION_DATA.lc[year];
+                if (yearData) {
+                    const candData = yearData.find(c => c.c === candidate && c.d === electorate);
+                    if (candData) {
+                        const elecData = yearData.filter(c => c.d === electorate);
+                        const total = elecData.reduce((sum, c) => sum + c.v, 0);
+                        const percent = (candData.v / total * 100);
+                        trendData.push({ year, percent });
+                    }
+                }
+            });
+
+            if (charts.trend) charts.trend.destroy();
+            if (trendData.length > 0) {
+                charts.trend = new Chart(ctx.getContext('2d'), {
+                    type: 'line',
+                    data: {
+                        labels: trendData.map(d => d.year),
+                        datasets: [{
+                            label: 'Primary Vote %',
+                            data: trendData.map(d => d.percent),
+                            borderColor: '#4A5A6A',
+                            backgroundColor: 'rgba(74, 90, 106, 0.1)',
+                            tension: 0.2
+                        }]
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        plugins: { legend: { display: false } },
+                        scales: {
+                            y: {
+                                beginAtZero: true,
+                                ticks: { callback: value => value + '%' }
+                            }
+                        }
+                    }
+                });
+            }
+        }
+
+        function createDistributionChart(boothStats) {
+            const ctx = document.getElementById('distributionChart');
+            if (!ctx) return;
+            const percentages = boothStats.map(b => b.percentage);
+            const min = Math.min(...percentages);
+            const max = Math.max(...percentages);
+            const binCount = 10;
+            const binSize = (max - min) / binCount;
+
+            const bins = [];
+            const binLabels = [];
+            for (let i = 0; i < binCount; i++) {
+                const binMin = min + i * binSize;
+                const binMax = binMin + binSize;
+                const count = percentages.filter(p => p >= binMin && p < binMax).length;
+                bins.push(count);
+                binLabels.push(`${binMin.toFixed(1)}-${binMax.toFixed(1)}%`);
+            }
+
+            if (charts.distribution) charts.distribution.destroy();
+            charts.distribution = new Chart(ctx.getContext('2d'), {
+                type: 'bar',
+                data: {
+                    labels: binLabels,
+                    datasets: [{
+                        label: 'Number of Booths',
+                        data: bins,
+                        backgroundColor: '#4A5A6A'
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: { legend: { display: false } },
+                    scales: {
+                        y: { beginAtZero: true, ticks: { precision: 0 } },
+                        x: { title: { display: true, text: 'Vote Share Range' } }
+                    }
+                }
+            });
+        }
+
+        function createCandidateBoothMap(boothStats, electorate) {
+            if (boothMap) {
+                boothMap.remove();
+            }
+            boothMap = L.map('boothMap').setView([-42.0, 147.0], 7);
+            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                attribution: '© OpenStreetMap contributors'
+            }).addTo(boothMap);
+            mapMarkers = L.layerGroup().addTo(boothMap);
+
+            const percentages = boothStats.map(b => b.percentage);
+            const maxPct = Math.max(...percentages);
+            const minPct = Math.min(...percentages);
+
+            boothStats.forEach(booth => {
+                const coords = POLLING_PLACES[booth.name] || POLLING_PLACES[keyForBooth(booth.name)];
+                if (coords && coords.lat && coords.lng) {
+                    const intensity = (booth.percentage - minPct) / (maxPct - minPct);
+                    const color = `hsl(${120 * intensity}, 70%, 50%)`;
+                    const icon = L.divIcon({
+                        className: 'custom-div-icon',
+                        html: `<div style="background-color:${color}; width: 20px; height: 20px; border-radius: 50%; border: 2px solid white; box-shadow: 0 1px 3px rgba(0,0,0,0.3);"></div>`,
+                        iconSize: [20, 20],
+                        iconAnchor: [10, 10]
+                    });
+                    const marker = L.marker([coords.lat, coords.lng], {icon});
+                    const popupContent = `
+                <div class="booth-popup">
+                    <h3>${booth.name}</h3>
+                    <p><strong>Votes:</strong> ${booth.votes.toLocaleString()}</p>
+                    <p><strong>Share:</strong> ${booth.percentage.toFixed(1)}%</p>
+                </div>`;
+                    marker.bindPopup(popupContent);
+                    mapMarkers.addLayer(marker);
+                }
+            });
+
+            const legend = L.control({position: 'bottomright'});
+            legend.onAdd = function(map) {
+                const div = L.DomUtil.create('div', 'map-legend');
+                div.innerHTML = `
+            <h4>Performance Scale</h4>
+            <div style="background: linear-gradient(to right, hsl(0, 70%, 50%), hsl(60, 70%, 50%), hsl(120, 70%, 50%)); height: 20px; margin: 5px 0;"></div>
+            <div style="display: flex; justify-content: space-between; font-size: 0.8rem;">
+                <span>${minPct.toFixed(1)}%</span>
+                <span>${maxPct.toFixed(1)}%</span>
+            </div>`;
+                return div;
+            };
+            legend.addTo(boothMap);
+            if (mapMarkers.getLayers().length > 0) {
+                boothMap.fitBounds(mapMarkers.getBounds(), {padding: [50, 50]});
+            }
         }
         
         // Chart creation functions
@@ -2089,41 +2542,6 @@ function renderHistoricalView(container) {
             });
         }
         
-        function createCandidateLocationChart(boothResults) {
-            const ctx = document.getElementById('candidateLocationChart');
-            if (!ctx) return;
-            
-            const top20 = boothResults.slice(0, 20);
-            
-            if (charts.candidateLocation) charts.candidateLocation.destroy();
-            
-            charts.candidateLocation = new Chart(ctx.getContext('2d'), {
-                type: 'bar',
-                data: {
-                    labels: top20.map(b => b.n),
-                    datasets: [{
-                        label: 'Votes',
-                        data: top20.map(b => b.v),
-                        backgroundColor: '#4A5A6A'
-                    }]
-                },
-                options: {
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    plugins: {
-                        legend: { display: false }
-                    },
-                    scales: {
-                        x: {
-                            ticks: {
-                                maxRotation: 45,
-                                minRotation: 45
-                            }
-                        }
-                    }
-                }
-            });
-        }
         
         function createBoothSelectionMap(electorate, selectedBooth = '') {
             if (boothMap) {


### PR DESCRIPTION
## Summary
- expand candidate view with detailed stats, historical comparisons, booth rankings and distribution analysis
- add supporting chart and map helpers for trend, distribution and booth performance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5103af6048332bd2551a843abfd04