### PR TITLE
feat: add automated candidate performance summary

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -1389,9 +1389,10 @@ function getPartyColor(party) {
         <div class="panel full-width">
             <h2>${candidateName}</h2>
             <p style="margin-top: -0.5rem; color: #666;">
-                <span style="color: ${getPartyColor(party)}; font-weight: 600;">${getPartyName(party)}</span> 
+                <span style="color: ${getPartyColor(party)}; font-weight: 600;">${getPartyName(party)}</span>
                 • ${electorate} • ${currentElectionType === 'state' ? 'State Election' : 'Legislative Council'} ${year}
             </p>
+            <p id="candidateSummary" style="margin-top: 0.5rem; color: #333;"></p>
         </div>
 
         <!-- Topline Performance -->
@@ -3199,6 +3200,11 @@ function createBoothFlipsChart() {
             const sortedParty = partyCandidates.sort((a, b) => b.v - a.v);
             const partyRank = sortedParty.findIndex(c => normalizeCandidateName(c.c) === candidateNorm) + 1;
 
+            const statewideData = getCurrentData(year, 'state', '', '', '');
+            const statewideParty = statewideData.filter(c => normalizeParty(c.p) === normalizedParty);
+            const sortedStateParty = statewideParty.sort((a, b) => b.v - a.v);
+            const statewidePartyRank = sortedStateParty.findIndex(c => normalizeCandidateName(c.c) === candidateNorm) + 1;
+
             document.getElementById('primaryVotes').textContent = totalVotes.toLocaleString();
             document.getElementById('primaryPercent').textContent = `${primaryPercent}% of electorate`;
             document.getElementById('partyShare').textContent = `${partyShare}%`;
@@ -3220,7 +3226,8 @@ function createBoothFlipsChart() {
                 return { name: booth.n, votes: booth.v, percentage, total: boothTotal };
             });
 
-            const sortedBooths = [...boothStats].sort((a, b) => b.percentage - a.percentage);
+            // Sort booths by raw vote count to identify highest and lowest performing booths
+            const sortedBooths = [...boothStats].sort((a, b) => b.votes - a.votes);
 
             const prevYear = getPreviousYear(year);
             let prevData = null;
@@ -3329,6 +3336,57 @@ function createBoothFlipsChart() {
             `;
                 });
             }
+
+            const formatList = items => {
+                if (items.length === 0) return '';
+                if (items.length === 1) return items[0];
+                if (items.length === 2) return `${items[0]} and ${items[1]}`;
+                return `${items.slice(0, -1).join(', ')}, and ${items[items.length - 1]}`;
+            };
+
+            const topBoothNames = sortedBooths.slice(0, 4).map(b => `${b.name} (${b.votes.toLocaleString()})`);
+            const bottomBoothNames = sortedBooths.slice(-5).map(b => `${b.name} (${b.votes.toLocaleString()})`).reverse();
+
+            const electAhead = sortedParty[partyRank - 2];
+            const electBehind = sortedParty[partyRank];
+            let electRankText = '';
+            if (electAhead && electBehind) {
+                electRankText = `, trailing ${electAhead.c} and ahead of ${electBehind.c}`;
+            } else if (electAhead) {
+                electRankText = `, trailing ${electAhead.c}`;
+            } else if (electBehind) {
+                electRankText = `, leading ${electBehind.c}`;
+            }
+
+            const stateAhead = sortedStateParty[statewidePartyRank - 2];
+            const stateBehind = sortedStateParty[statewidePartyRank];
+            let stateRankText = '';
+            if (stateAhead && stateBehind) {
+                stateRankText = `, trailing ${stateAhead.c} (${stateAhead.d}) and ahead of ${stateBehind.c} (${stateBehind.d})`;
+            } else if (stateAhead) {
+                stateRankText = `, trailing ${stateAhead.c} (${stateAhead.d})`;
+            } else if (stateBehind) {
+                stateRankText = `, leading ${stateBehind.c} (${stateBehind.d})`;
+            }
+
+            let summary = `${candidate} achieved a first preference result of ${totalVotes.toLocaleString()} or ${primaryPercent}%.`;
+            const electorateComparison = normalizedParty === 'IND' ? 'other independent candidates' : 'others in their party';
+            const statewideComparison = normalizedParty === 'IND' ? 'all other independent candidates' : `all other ${getPartyName(party)} candidates`;
+            summary += ` They ranked #${partyRank} compared to ${electorateComparison} within the electorate of ${electorate}${electRankText}, and #${statewidePartyRank} compared to ${statewideComparison} across all electorates${stateRankText}.`;
+            if (topBoothNames.length > 0) {
+                summary += ` Their highest performing booths were ${formatList(topBoothNames)}.`;
+            }
+            if (bottomBoothNames.length > 0) {
+                summary += ` While their lowest performing booths were ${formatList(bottomBoothNames)}.`;
+            }
+            if (prevData && swing !== null) {
+                const perf = parseFloat(swing) > 0 ? 'better' : parseFloat(swing) < 0 ? 'worse' : 'the same';
+                summary += ` Compared to their previous election results, they achieved a ${perf} result, with an overall swing of ${parseFloat(swing) > 0 ? '+' : ''}${swing}%.`;
+            } else {
+                summary += ' No previous election data available for comparison.';
+            }
+            const summaryEl = document.getElementById('candidateSummary');
+            if (summaryEl) summaryEl.textContent = summary;
 
             const percentages = boothStats.map(b => b.percentage);
             percentages.sort((a, b) => a - b);


### PR DESCRIPTION
## Summary
- show summary container on individual candidate view
- generate automated performance summary including statewide party rank, top/bottom booths, and swing vs previous election
- sort booth rankings by vote count
- clarify ranking phrasing for independent candidates
- include booth vote counts and name the candidates immediately ahead and behind in party rankings at electorate and statewide levels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5427ef9b8833289813cd1fde679d3