### PR TITLE
Add booth performance map mode toggle

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -1495,8 +1495,8 @@ function getPartyColor(party) {
             <div style="margin-top: 1.5rem;">
                 <h3>Booth Map - Candidate Performance</h3>
                 <div id="boothMapToggle" style="margin: 0.25rem 0 0.5rem 0; display:flex; gap:0.5rem; flex-wrap:wrap;">
-                    <button id="boothShareBtn" class="active" title="Color booths by vote share">Share %</button>
-                    <button id="boothVotesBtn" title="Color booths by raw votes">Votes</button>
+                    <button id="boothShareBtn" type="button" class="active" title="Color booths by vote share">Share %</button>
+                    <button id="boothVotesBtn" type="button" title="Color booths by raw votes">Votes</button>
                 </div>
                 <div id="boothMap"></div>
             </div>
@@ -3495,16 +3495,18 @@ function createBoothFlipsChart() {
             const shareBtn = document.getElementById('boothShareBtn');
             const votesBtn = document.getElementById('boothVotesBtn');
             if (shareBtn && votesBtn) {
-                shareBtn.onclick = () => {
+                shareBtn.addEventListener('click', (e) => {
+                    e.preventDefault();
                     shareBtn.classList.add('active');
                     votesBtn.classList.remove('active');
                     createCandidateBoothMap(boothStats, electorate, 'share');
-                };
-                votesBtn.onclick = () => {
+                });
+                votesBtn.addEventListener('click', (e) => {
+                    e.preventDefault();
                     votesBtn.classList.add('active');
                     shareBtn.classList.remove('active');
                     createCandidateBoothMap(boothStats, electorate, 'votes');
-                };
+                });
             }
         }
 

--- a/Index.html
+++ b/Index.html
@@ -3613,32 +3613,37 @@ function createBoothFlipsChart() {
                 attribution: '© OpenStreetMap contributors'
             }).addTo(boothMap);
             mapMarkers = L.layerGroup().addTo(boothMap);
-            const values = boothStats.map(b => mode === 'votes' ? b.votes : b.percentage);
+
+            // Only consider booths that can be mapped when calculating color scale
+            const plottableBooths = boothStats.filter(b => {
+                const coords = POLLING_PLACES[b.name] || POLLING_PLACES[keyForBooth(b.name)];
+                return coords && coords.lat && coords.lng;
+            });
+
+            const values = plottableBooths.map(b => mode === 'votes' ? b.votes : b.percentage);
             const maxVal = Math.max(...values);
             const minVal = Math.min(...values);
 
-            boothStats.forEach(booth => {
+            plottableBooths.forEach(booth => {
                 const coords = POLLING_PLACES[booth.name] || POLLING_PLACES[keyForBooth(booth.name)];
-                if (coords && coords.lat && coords.lng) {
-                    const boothValue = mode === 'votes' ? booth.votes : booth.percentage;
-                    const intensity = (boothValue - minVal) / (maxVal - minVal || 1);
-                    const color = `hsl(${120 * intensity}, 70%, 50%)`;
-                    const icon = L.divIcon({
-                        className: 'custom-div-icon',
-                        html: `<div style="background-color:${color}; width: 20px; height: 20px; border-radius: 50%; border: 2px solid white; box-shadow: 0 1px 3px rgba(0,0,0,0.3);"></div>`,
-                        iconSize: [20, 20],
-                        iconAnchor: [10, 10]
-                    });
-                    const marker = L.marker([coords.lat, coords.lng], {icon});
-                    const popupContent = `
+                const boothValue = mode === 'votes' ? booth.votes : booth.percentage;
+                const intensity = (boothValue - minVal) / (maxVal - minVal || 1);
+                const color = `hsl(${120 * intensity}, 70%, 50%)`;
+                const icon = L.divIcon({
+                    className: 'custom-div-icon',
+                    html: `<div style="background-color:${color}; width: 20px; height: 20px; border-radius: 50%; border: 2px solid white; box-shadow: 0 1px 3px rgba(0,0,0,0.3);"></div>`,
+                    iconSize: [20, 20],
+                    iconAnchor: [10, 10]
+                });
+                const marker = L.marker([coords.lat, coords.lng], {icon});
+                const popupContent = `
                 <div class="booth-popup">
                     <h3>${booth.name}</h3>
                     <p><strong>Votes:</strong> ${booth.votes.toLocaleString()}</p>
                     <p><strong>Share:</strong> ${booth.percentage.toFixed(1)}%</p>
                 </div>`;
-                    marker.bindPopup(popupContent);
-                    mapMarkers.addLayer(marker);
-                }
+                marker.bindPopup(popupContent);
+                mapMarkers.addLayer(marker);
             });
 
             const legend = L.control({position: 'bottomright'});

--- a/Index.html
+++ b/Index.html
@@ -1494,6 +1494,10 @@ function getPartyColor(party) {
             
             <div style="margin-top: 1.5rem;">
                 <h3>Booth Map - Candidate Performance</h3>
+                <div id="boothMapToggle" style="margin: 0.25rem 0 0.5rem 0; display:flex; gap:0.5rem; flex-wrap:wrap;">
+                    <button id="boothShareBtn" class="active" title="Color booths by vote share">Share %</button>
+                    <button id="boothVotesBtn" title="Color booths by raw votes">Votes</button>
+                </div>
                 <div id="boothMap"></div>
             </div>
         </div>
@@ -3486,7 +3490,22 @@ function createBoothFlipsChart() {
 
             createCandidateTrendChart(candidate, electorate);
             createDistributionChart(boothStats);
-            createCandidateBoothMap(boothStats, electorate);
+            createCandidateBoothMap(boothStats, electorate, 'share');
+
+            const shareBtn = document.getElementById('boothShareBtn');
+            const votesBtn = document.getElementById('boothVotesBtn');
+            if (shareBtn && votesBtn) {
+                shareBtn.onclick = () => {
+                    shareBtn.classList.add('active');
+                    votesBtn.classList.remove('active');
+                    createCandidateBoothMap(boothStats, electorate, 'share');
+                };
+                votesBtn.onclick = () => {
+                    votesBtn.classList.add('active');
+                    shareBtn.classList.remove('active');
+                    createCandidateBoothMap(boothStats, electorate, 'votes');
+                };
+            }
         }
 
         function createCandidateTrendChart(candidate, electorate) {
@@ -3585,7 +3604,7 @@ function createBoothFlipsChart() {
             });
         }
 
-        function createCandidateBoothMap(boothStats, electorate) {
+        function createCandidateBoothMap(boothStats, electorate, mode = 'share') {
             if (boothMap) {
                 boothMap.remove();
             }
@@ -3594,15 +3613,15 @@ function createBoothFlipsChart() {
                 attribution: '© OpenStreetMap contributors'
             }).addTo(boothMap);
             mapMarkers = L.layerGroup().addTo(boothMap);
-
-            const percentages = boothStats.map(b => b.percentage);
-            const maxPct = Math.max(...percentages);
-            const minPct = Math.min(...percentages);
+            const values = boothStats.map(b => mode === 'votes' ? b.votes : b.percentage);
+            const maxVal = Math.max(...values);
+            const minVal = Math.min(...values);
 
             boothStats.forEach(booth => {
                 const coords = POLLING_PLACES[booth.name] || POLLING_PLACES[keyForBooth(booth.name)];
                 if (coords && coords.lat && coords.lng) {
-                    const intensity = (booth.percentage - minPct) / (maxPct - minPct);
+                    const boothValue = mode === 'votes' ? booth.votes : booth.percentage;
+                    const intensity = (boothValue - minVal) / (maxVal - minVal || 1);
                     const color = `hsl(${120 * intensity}, 70%, 50%)`;
                     const icon = L.divIcon({
                         className: 'custom-div-icon',
@@ -3625,12 +3644,15 @@ function createBoothFlipsChart() {
             const legend = L.control({position: 'bottomright'});
             legend.onAdd = function(map) {
                 const div = L.DomUtil.create('div', 'map-legend');
+                const title = mode === 'votes' ? 'Vote Scale' : 'Performance Scale';
+                const minLabel = mode === 'votes' ? minVal.toLocaleString() : `${minVal.toFixed(1)}%`;
+                const maxLabel = mode === 'votes' ? maxVal.toLocaleString() : `${maxVal.toFixed(1)}%`;
                 div.innerHTML = `
-            <h4>Performance Scale</h4>
+            <h4>${title}</h4>
             <div style="background: linear-gradient(to right, hsl(0, 70%, 50%), hsl(60, 70%, 50%), hsl(120, 70%, 50%)); height: 20px; margin: 5px 0;"></div>
             <div style="display: flex; justify-content: space-between; font-size: 0.8rem;">
-                <span>${minPct.toFixed(1)}%</span>
-                <span>${maxPct.toFixed(1)}%</span>
+                <span>${minLabel}</span>
+                <span>${maxLabel}</span>
             </div>`;
                 return div;
             };


### PR DESCRIPTION
## Summary
- add toggle to booth performance map to switch between vote share and raw votes
- color markers and legend based on selected mode in createCandidateBoothMap
- re-render map when Share % or Votes option selected

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a56adee0f08332a3470190560a6188